### PR TITLE
Fix error retrieving config when shutting down pools when hapi server is stopped

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -88,7 +88,7 @@ exports.plugin = {
         server.events.on('stop', () => {
             ;[].concat(expose.pool).forEach(pool => {
                 try {
-                    const poolConfig = pool.config.connectionConfig
+                    const poolConfig = pool.pool.config.connectionConfig
                     const info = `${poolConfig.user}@${poolConfig.host}`
                     server.log(
                         ['hapi-mysql2', 'info'],

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -245,3 +245,37 @@ test('should fail to mix different decorations', async () => {
         )
     }
 })
+
+test('should shut down pool when server stops', async () => {
+    const server = createServer()
+    await server.register({
+        plugin: require('./'),
+        options: [
+            {
+                settings: getUrl(),
+                decorate: true
+            }
+        ]
+    })
+    server.route({
+        method: 'GET',
+        path: '/connection',
+        handler: async request => {
+            const connection = await request.server.mysql.pool.getConnection();
+            connection.release();
+        }
+    })
+
+    await server.inject({
+        validate: false,
+        method: 'GET',
+        url: '/connection'
+    })
+
+    const errors = []
+    server.events.on({name: 'log', filter: 'error'}, event => {
+        errors.push(event)
+    })
+    await server.stop()
+    expect(errors).toEqual([])
+})


### PR DESCRIPTION
The mysql2/promise wrapper doesn't expose config on it's pool wrapper so the config has to be retrieved with pool.pool.config instead of just pool.config.  The hapi stop handler is currently throwing the error:
TypeError: Cannot read property 'connectionConfig' of undefined]
and failing to shutdown the pool.